### PR TITLE
test(serf-reactor): port the join/leave membership-lifecycle scenarios

### DIFF
--- a/serf-reactor/tests/cluster/mod.rs
+++ b/serf-reactor/tests/cluster/mod.rs
@@ -439,6 +439,26 @@ where
     .unwrap_or_else(|_| panic!("node {observer} never holds {subject:?} as a Left tombstone"));
   }
 
+  /// Poll until `observer`'s membership view holds `subject` with `status`, or
+  /// fail on the poll timeout.
+  pub async fn await_member_status(&self, observer: usize, subject: &str, status: MemberStatus) {
+    R::timeout(POLL_TIMEOUT, async {
+      loop {
+        if self
+          .node(observer)
+          .members()
+          .iter()
+          .any(|m| m.node().id_ref().as_str() == subject && m.status() == status)
+        {
+          break;
+        }
+        R::sleep(POLL_STEP).await;
+      }
+    })
+    .await
+    .unwrap_or_else(|_| panic!("node {observer} never holds {subject:?} as {status:?}"));
+  }
+
   /// Poll until `observer`'s log records a member event of `kind` naming
   /// `subject`.
   pub async fn await_member_event(&self, observer: usize, subject: &str, kind: MemberEventKind) {

--- a/serf-reactor/tests/cluster/mod.rs
+++ b/serf-reactor/tests/cluster/mod.rs
@@ -303,8 +303,11 @@ where
 
   /// Gracefully leave node `i` but keep its handle LIVE — unlike
   /// [`leave_graceful`](Self::leave_graceful), no shutdown follows. Lets an
-  /// assertion observe the leaver's OWN post-leave convergence (it reaps its
-  /// self Left tombstone back to the surviving peer) before teardown.
+  /// assertion observe the leaver's OWN post-leave convergence before teardown.
+  /// Read that convergence from the event log, not `members()`: the leaver
+  /// reaps its self Left tombstone, but the published snapshot then freezes
+  /// (`refresh_snapshot` will not publish a view missing the local id), so the
+  /// event stream — not the membership view — is the source of truth here.
   pub async fn leave_in_place(&self, i: usize) {
     self
       .node(i)

--- a/serf-reactor/tests/cluster/mod.rs
+++ b/serf-reactor/tests/cluster/mod.rs
@@ -301,6 +301,18 @@ where
     elapsed
   }
 
+  /// Gracefully leave node `i` but keep its handle LIVE — unlike
+  /// [`leave_graceful`](Self::leave_graceful), no shutdown follows. Lets an
+  /// assertion observe the leaver's OWN post-leave convergence (it reaps its
+  /// self Left tombstone back to the surviving peer) before teardown.
+  pub async fn leave_in_place(&self, i: usize) {
+    self
+      .node(i)
+      .leave()
+      .await
+      .expect("node leaves gracefully in place");
+  }
+
   /// Gracefully leave node `i` with a shutdown racing the leave: both commands
   /// are issued concurrently, so they typically land in the same driver command
   /// batch and the teardown itself must egress the still-queued farewell before

--- a/serf-reactor/tests/tcp.rs
+++ b/serf-reactor/tests/tcp.rs
@@ -1826,14 +1826,15 @@ where
 /// checks the leaver's own side, not just the observer's.
 ///
 /// The leaver is kept running rather than shut down so its convergence is
-/// observable. It diverges from the legacy leaver in one deliberate way: the
-/// legacy leaver reaped its self Left tombstone to a member count of 1, but the
-/// reactor keeps the local node in its own view (only peer tombstones are
-/// reaped — the reap loop walks `left_members`, and a node's own leave-in-place
-/// does not tombstone-reap itself). So the leaver-side invariant is the
-/// self → Left transition beside a still-live peer, which is what actually
-/// guards against the leaver dropping a live peer or never processing its own
-/// departure; the count-to-one reap is asserted on the observer.
+/// observable, but its side must be read from the EVENT LOG, not the membership
+/// snapshot. The leaver reaps its own self Left tombstone (matching the legacy
+/// leaver) — `handle_node_leave` adds self to `left_members` and `fire_reap`
+/// removes it — but once self is gone from the machine, `refresh_snapshot`
+/// refuses to publish a view missing the local id, so `members()` /
+/// `num_members()` FREEZE at the pre-reap `[peer, self:Left]` state. The event
+/// stream stays truthful: the leaver emits `Leave` then `Reap` for itself and
+/// only a `Join` for the peer. (The frozen-snapshot-vs-event divergence for a
+/// left-in-place node is tracked as a separate machine-side issue, al8n/serf#88.)
 async fn serf_join_leave<R>()
 where
   R: Runtime,
@@ -1847,16 +1848,25 @@ where
   cluster.leave_in_place(1).await;
 
   // A (observer) reaps the departed B under the fast profile's 1ms tombstone +
-  // 100ms reap ticks, returning to just itself.
+  // 100ms reap ticks, returning to just itself (A's own snapshot stays live).
   cluster.await_num_members(0, 1).await;
 
-  // B (the leaver) processes its own departure — self becomes Left — while
-  // still tracking the live peer A.
+  // B (the leaver) processes its own departure end to end: its event log shows
+  // Join → Leave → Reap for itself — self IS reaped under the default tombstone.
   cluster
-    .await_member_status(1, leaver.as_str(), MemberStatus::Left)
+    .assert_member_events(
+      1,
+      leaver.as_str(),
+      &[
+        MemberEventKind::Join,
+        MemberEventKind::Leave,
+        MemberEventKind::Reap,
+      ],
+    )
     .await;
+  // And it never fails or reaps the still-live peer — only the Join.
   cluster
-    .await_member_status(1, peer.as_str(), MemberStatus::Alive)
+    .assert_member_events(1, peer.as_str(), &[MemberEventKind::Join])
     .await;
 
   cluster.shutdown_all().await;

--- a/serf-reactor/tests/tcp.rs
+++ b/serf-reactor/tests/tcp.rs
@@ -25,7 +25,7 @@ use bytes::Bytes;
 use futures_util::{StreamExt, future};
 use serf_proto::{
   event::{Event, MemberEventKind},
-  members::SerfState,
+  members::{MemberStatus, SerfState},
   options::Options as SerfOptions,
 };
 #[cfg(encryption)]
@@ -1818,6 +1818,122 @@ where
   c.shutdown().await.expect("qf-c shuts down");
 }
 
+/// Port of legacy `serf_join_leave` (Go `TestSerf_JoinLeave`): after a peer
+/// leaves gracefully, the observer reaps its Left tombstone under the DEFAULT
+/// timeout and drops back to a single member. The other leave e2es deliberately
+/// raise the tombstone timeout to hold the tombstone and pin the event
+/// sequence; this one exercises the plain default-tombstone reap that returns
+/// the cluster to N-1 — a path none of them cover.
+async fn serf_join_leave<R>()
+where
+  R: Runtime,
+{
+  let mut cluster =
+    cluster::Cluster::<R>::spawn(&["jl-a", "jl-b"], cluster::ClusterTiming::fast()).await;
+
+  cluster.leave_graceful(1).await;
+
+  // The fast profile's 1ms tombstone plus 100ms reap ticks drop B's Left
+  // tombstone, returning A to a single member.
+  cluster.await_num_members(0, 1).await;
+
+  cluster.shutdown_all().await;
+}
+
+/// Port of legacy `serf_join_leave_join` (Go `TestSerf_JoinLeaveJoin`): a peer
+/// leaves — the observer holds it as a Left tombstone — then the same node
+/// restarts and rejoins, and the observer transitions it Left → Alive. The
+/// tombstone timeout is raised so the Left state is observable before the
+/// rejoin rather than reaped away first.
+async fn serf_join_leave_join<R>()
+where
+  R: Runtime,
+{
+  let mut cluster = cluster::Cluster::<R>::spawn(
+    &["jlj-a", "jlj-b"],
+    cluster::ClusterTiming::fast().with_tombstone_timeout(Duration::from_secs(30)),
+  )
+  .await;
+  let subject = cluster.id(1);
+  let seed = cluster.node(0).advertise_address();
+
+  cluster.leave_graceful(1).await;
+  cluster.await_left_tombstone(0, subject.as_str()).await;
+
+  cluster.restart(1).await;
+  cluster
+    .node(1)
+    .join(&SocketAddrResolver, MaybeResolved::Resolved(seed), false)
+    .await
+    .expect("the restarted node rejoins the seed");
+
+  // A transitions B from its Left tombstone back to Alive.
+  cluster
+    .await_member_status(0, subject.as_str(), MemberStatus::Alive)
+    .await;
+
+  cluster.shutdown_all().await;
+}
+
+/// Port of legacy `serf_leave_rejoin_different_role` (Go
+/// `TestSerf_LeaveRejoin_DifferentRole`): a node leaves, then a fresh node
+/// rejoins at the SAME id and address carrying a DIFFERENT role tag, and the
+/// observer's view reflects the new role. The legacy test sets the role at
+/// construction; the Sans-I/O stack has no start-time tag surface, so the
+/// restarted node applies it via `set_tags` before the rejoin — the revival
+/// folds the tag into its Join (matching the reference `handleNodeJoin`), and
+/// the observer ends up seeing the new value.
+async fn serf_leave_rejoin_different_role<R>()
+where
+  R: Runtime,
+{
+  let mut cluster = cluster::Cluster::<R>::spawn(
+    &["lrr-a", "lrr-b"],
+    cluster::ClusterTiming::fast().with_tombstone_timeout(Duration::from_secs(30)),
+  )
+  .await;
+  let subject = cluster.id(1);
+  let seed = cluster.node(0).advertise_address();
+
+  cluster.leave_graceful(1).await;
+  cluster.await_left_tombstone(0, subject.as_str()).await;
+
+  cluster.restart(1).await;
+  let mut tags = serf_proto::Tags::new();
+  tags.0.insert(SmolStr::new("role"), SmolStr::new("bar"));
+  cluster
+    .node(1)
+    .set_tags(tags)
+    .await
+    .expect("the restarted node adopts the new role before rejoining");
+  cluster
+    .node(1)
+    .join(&SocketAddrResolver, MaybeResolved::Resolved(seed), false)
+    .await
+    .expect("the re-roled node rejoins the seed");
+
+  // A must see B back as Alive AND carrying the new role — the two ride the
+  // same revival Join, so poll them together to avoid reading the view between
+  // the status flip and the tag landing.
+  R::timeout(Duration::from_secs(20), async {
+    loop {
+      let seen = cluster.node(0).members().iter().any(|m| {
+        m.node().id_ref().as_str() == subject.as_str()
+          && m.status() == MemberStatus::Alive
+          && m.tags().0.get("role").map(SmolStr::as_str) == Some("bar")
+      });
+      if seen {
+        break;
+      }
+      R::sleep(Duration::from_millis(20)).await;
+    }
+  })
+  .await
+  .expect("A never sees the rejoined B as Alive carrying role=bar");
+
+  cluster.shutdown_all().await;
+}
+
 /// A deterministic test secret key, selecting whichever AEAD cipher this build
 /// compiled so the encrypted tests work under either backend.
 #[cfg(encryption)]
@@ -2116,6 +2232,21 @@ mod tokio_cells {
     super::serf_query_filter::<TokioRuntime>().await;
   }
 
+  #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+  async fn serf_join_leave() {
+    super::serf_join_leave::<TokioRuntime>().await;
+  }
+
+  #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+  async fn serf_join_leave_join() {
+    super::serf_join_leave_join::<TokioRuntime>().await;
+  }
+
+  #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+  async fn serf_leave_rejoin_different_role() {
+    super::serf_leave_rejoin_different_role::<TokioRuntime>().await;
+  }
+
   #[cfg(encryption)]
   #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
   async fn two_node_join_converges_encrypted() {
@@ -2283,6 +2414,21 @@ mod smol_cells {
   #[test]
   fn serf_query_filter_smol() {
     SmolRuntime::block_on(super::serf_query_filter::<SmolRuntime>());
+  }
+
+  #[test]
+  fn serf_join_leave_smol() {
+    SmolRuntime::block_on(super::serf_join_leave::<SmolRuntime>());
+  }
+
+  #[test]
+  fn serf_join_leave_join_smol() {
+    SmolRuntime::block_on(super::serf_join_leave_join::<SmolRuntime>());
+  }
+
+  #[test]
+  fn serf_leave_rejoin_different_role_smol() {
+    SmolRuntime::block_on(super::serf_leave_rejoin_different_role::<SmolRuntime>());
   }
 
   #[cfg(encryption)]

--- a/serf-reactor/tests/tcp.rs
+++ b/serf-reactor/tests/tcp.rs
@@ -1819,23 +1819,45 @@ where
 }
 
 /// Port of legacy `serf_join_leave` (Go `TestSerf_JoinLeave`): after a peer
-/// leaves gracefully, the observer reaps its Left tombstone under the DEFAULT
-/// timeout and drops back to a single member. The other leave e2es deliberately
-/// raise the tombstone timeout to hold the tombstone and pin the event
-/// sequence; this one exercises the plain default-tombstone reap that returns
-/// the cluster to N-1 — a path none of them cover.
+/// leaves gracefully, the departure settles on BOTH sides under the DEFAULT
+/// tombstone timeout. The other leave e2es raise the tombstone timeout to HOLD
+/// the tombstone and pin the event sequence; this one exercises the plain
+/// default-tombstone reap that none of them cover, and — like the legacy body —
+/// checks the leaver's own side, not just the observer's.
+///
+/// The leaver is kept running rather than shut down so its convergence is
+/// observable. It diverges from the legacy leaver in one deliberate way: the
+/// legacy leaver reaped its self Left tombstone to a member count of 1, but the
+/// reactor keeps the local node in its own view (only peer tombstones are
+/// reaped — the reap loop walks `left_members`, and a node's own leave-in-place
+/// does not tombstone-reap itself). So the leaver-side invariant is the
+/// self → Left transition beside a still-live peer, which is what actually
+/// guards against the leaver dropping a live peer or never processing its own
+/// departure; the count-to-one reap is asserted on the observer.
 async fn serf_join_leave<R>()
 where
   R: Runtime,
 {
   let mut cluster =
     cluster::Cluster::<R>::spawn(&["jl-a", "jl-b"], cluster::ClusterTiming::fast()).await;
+  let peer = cluster.id(0);
+  let leaver = cluster.id(1);
 
-  cluster.leave_graceful(1).await;
+  // Leave in place — keep B's handle live so its own convergence is observable.
+  cluster.leave_in_place(1).await;
 
-  // The fast profile's 1ms tombstone plus 100ms reap ticks drop B's Left
-  // tombstone, returning A to a single member.
+  // A (observer) reaps the departed B under the fast profile's 1ms tombstone +
+  // 100ms reap ticks, returning to just itself.
   cluster.await_num_members(0, 1).await;
+
+  // B (the leaver) processes its own departure — self becomes Left — while
+  // still tracking the live peer A.
+  cluster
+    .await_member_status(1, leaver.as_str(), MemberStatus::Left)
+    .await;
+  cluster
+    .await_member_status(1, peer.as_str(), MemberStatus::Alive)
+    .await;
 
   cluster.shutdown_all().await;
 }


### PR DESCRIPTION
## Scope

three legacy driver e2es onto the serf-reactor TCP cluster fixture, test-only plus two small fixture helpers. Confirmed unported by a four-agent mapping of the 68 legacy `serf-core` test bodies (58 already ported e2e or deduped to machine tests; these three had no equivalent).

- **`serf_join_leave`** (Go `TestSerf_JoinLeave`): the plain DEFAULT-tombstone reap — a path the other leave e2es deliberately avoid by holding the tombstone. The observer reaps the departed peer back to a single member; the leaver is kept running and its own convergence is read from the EVENT LOG (`[Join, Leave, Reap]` for itself — self is reaped — and only `[Join]` for the still-live peer). The membership snapshot is not a valid observable here: the leaver reaps its self tombstone but `refresh_snapshot` then freezes because the local id is absent, a divergence filed as #88.
- **`serf_join_leave_join`** (Go `TestSerf_JoinLeaveJoin`): the Left → rejoin → Alive cycle (tombstone raised so the Left state is observable, then restart at the same id+address and explicit rejoin).
- **`serf_leave_rejoin_different_role`** (Go `TestSerf_LeaveRejoin_DifferentRole`): a rejoin carrying a CHANGED role. No start-time tag surface exists, so the restarted node applies the role via `set_tags` before rejoining and the revival folds it into the Join; status and tag are polled together.

Fixture: `await_member_status` (view-side status fence) and `leave_in_place` (leave without the trailing shutdown, so the leaver's own convergence is observable).